### PR TITLE
Test and fix database connection with the Chatbot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Add parameter to use database from ChatBot class
+- Fix ban, poll end, prediction lock, prediction end trigger callback
+- Fix start and end date for poll and prediction for database ingestion
+- Fix call trigger callback with no parameter
+- Fix insert sql request
+- Call all table creation if no database exist
+
 ## [0.1.0] (05/03/2024)
 
 ### Added
@@ -19,4 +29,3 @@
 - Add user action to interact with the chat
 - Stream information are stored in a SQLite3 data base
 - Add class to standardize twitch right
-

--- a/twitchapi/chatbot.py
+++ b/twitchapi/chatbot.py
@@ -150,7 +150,7 @@ class ChatBot:
     def prediction_end(self, title: str, result: dict, winning_pred: str):
         pass
 
-    def new_ban(self, user_name: str, moderator_name:str, reason: str, start_ban: str, end_date: str, permanent: bool):
+    def new_ban(self, user_name: str, moderator_name:str, reason: str, start_ban: str, end_ban: str, permanent: bool):
         pass
 
     def new_vip(self, user_name: str):

--- a/twitchapi/chatbot.py
+++ b/twitchapi/chatbot.py
@@ -12,7 +12,7 @@ class ChatBot:
 
     def __init__(self, client_id: str, client_secret: str, bot_name: str, channel_name: str, subscriptions: list[str],
                  redirect_uri_auth: str = REDIRECT_URI_AUTH, timeout=DEFAULT_TIMEOUT, right: list[str] = None,
-                 channel_point_subscription: list[str] = None):
+                 channel_point_subscription: list[str] = None, store_in_db:bool=False):
         self._client_id = client_id
         self.__client_secret = client_secret
 
@@ -57,7 +57,7 @@ class ChatBot:
         self.__event_sub = EventSub(bot_id=self._bot_id, channel_id=self._channel_id,
                                     subscription_types=self.__subscription, auth_server=self.__auth,
                                     trigger_map=self.__trigger_map,
-                                    channel_point_subscription=channel_point_subscription)
+                                    channel_point_subscription=channel_point_subscription, store_in_db=store_in_db)
 
         self.__thread = ThreadWithExc(target=self.__run_event_server)
         self.__thread.start()

--- a/twitchapi/db.py
+++ b/twitchapi/db.py
@@ -23,7 +23,7 @@ class DataBaseTemplate:
 
     FOLLOW = """INSERT INTO follow 
                 VALUES('<id>', '<user>', '<user_id>', DATETIME('<date>', 'subsec'), 
-                       <DATETIME('<follow_date>', 'subsec'))"""
+                       DATETIME('<follow_date>', 'subsec'))"""
 
     SUBSCRIBE = """INSERT INTO subscribe (id, user, user_id, date, tier, is_gift, duration)
                    VALUES('<id>', '<user>', '<user_id>', DATETIME('<date>', 'subsec'), '<tier>', <is_gift>, 1)
@@ -53,7 +53,7 @@ class DataBaseTemplate:
                     VALUES('<id>', '<title>', '<winning_outcome>', '<winning_outcome_id>', 
                            DATETIME('<start_date>', 'subsec'), DATETIME('<end_date>', 'subsec'), '<status>')"""
 
-    PREDICTION_CHOICES = """INSERT INTO poll_choices
+    PREDICTION_CHOICES = """INSERT INTO prediction_choices
                             VALUES('<id>', '<title>', <nb_users>, <channel_points>, '<prediction_id>')"""
 
     BAN = """INSERT INTO ban
@@ -75,7 +75,7 @@ class DataBaseTemplate:
             marker = f"<{param}>"
             if marker not in script:
                 raise AttributeError(f"{param} is not supported by the endpoint {script}")
-            script = script.replace(marker, kwargs[param])
+            script = script.replace(marker, str(kwargs[param]))
         return script
 
 
@@ -166,7 +166,8 @@ class DataBaseManager:
                               bits_votes INT,
                               channel_points_votes INT,
                               votes INT NOT NULL,
-                              poll_id VARCHAR(36) FOREIGN KEY REFERENCES poll(id)
+                              poll_id VARCHAR(36),
+                              FOREIGN KEY(poll_id) REFERENCES poll(id)
                           )"""
 
         PREDICTION = """CREATE TABLE prediction (
@@ -184,7 +185,8 @@ class DataBaseManager:
                                     title TEXT NOT NULL,
                                     nb_users INT NOT NULL,
                                     channel_points INT NOT NULL,
-                                    prediction_id VARCHAR(36) FOREIGN KEY REFERENCES prediction(id)
+                                    prediction_id VARCHAR(36),
+                                    FOREIGN KEY(prediction_id) REFERENCES prediction(id)
                                 )"""
 
         BAN = """CREATE TABLE ban (
@@ -202,7 +204,7 @@ class DataBaseManager:
         VIP = """CREATE TABLE vip (
                      user_id VARCHAR(100) PRIMARY KEY NOT NULL,
                      user VARCHAR(100) NOT NULL,
-                     date DATE NOT NULL,
+                     date DATE NOT NULL
                  )"""
 
         BITS = """CREATE TABLE bits(

--- a/twitchapi/db.py
+++ b/twitchapi/db.py
@@ -195,7 +195,7 @@ class DataBaseManager:
                      moderator_id VARCHAR(100) NOT NULL,
                      reason TEXT NOT NULL,
                      start_ban DATE NOT NULL,
-                     end_ban DATE NOT NULL,
+                     end_ban DATE,
                      is_permanent BOOLEAN NOT NULL
                  )"""
 
@@ -234,6 +234,18 @@ class DataBaseManager:
         cursor = db.cursor()
 
         cursor.execute(self.__InitDataBaseTemplate.MESSAGE)
+        cursor.execute(self.__InitDataBaseTemplate.CHANNEL_POINT_ACTION)
+        cursor.execute(self.__InitDataBaseTemplate.FOLLOW)
+        cursor.execute(self.__InitDataBaseTemplate.SUBSCRIBE)
+        cursor.execute(self.__InitDataBaseTemplate.SUBGIFT)
+        cursor.execute(self.__InitDataBaseTemplate.RAID)
+        cursor.execute(self.__InitDataBaseTemplate.POLL)
+        cursor.execute(self.__InitDataBaseTemplate.POLL_CHOICES)
+        cursor.execute(self.__InitDataBaseTemplate.PREDICTION)
+        cursor.execute(self.__InitDataBaseTemplate.PREDICTION_CHOICES)
+        cursor.execute(self.__InitDataBaseTemplate.BAN)
+        cursor.execute(self.__InitDataBaseTemplate.VIP)
+        cursor.execute(self.__InitDataBaseTemplate.BITS)
         db.commit()
         db.close()
 

--- a/twitchapi/eventsub.py
+++ b/twitchapi/eventsub.py
@@ -1,5 +1,4 @@
 import logging
-from sys import exception
 from typing import Any
 
 from websocket import WebSocketApp
@@ -7,11 +6,10 @@ from websocket import WebSocketApp
 from twitchapi.auth import AuthServer
 from twitchapi.twitchcom import TwitchEndpoint, TriggerSignal, TwitchSubscriptionModel, \
     TwitchSubscriptionType
-from twitchapi.utils import ThreadWithExc, TriggerMap
-from twitchapi.exception import KillThreadException, TwitchEventSubError, TwitchAuthorizationFailed
+from twitchapi.utils import TriggerMap
+from twitchapi.exception import TwitchEventSubError, TwitchAuthorizationFailed
 import json
 import os
-from threading import Lock
 from twitchapi.db import DataBaseManager, DataBaseTemplate
 
 SOURCE_ROOT = os.path.dirname(__file__)
@@ -129,6 +127,10 @@ class EventSub(WebSocketApp):
                         case TwitchSubscriptionType.VIP_ADD:
                             logging.info("Process a VIP added")
                             self.__process_vip_add(event=event, date=msg_timestamp)
+
+                        case TwitchSubscriptionType.VIP_REMOVE:
+                            logging.info("Process a VIP removed")
+                            self.__process_vip_remove(event=event)
 
                         case TwitchSubscriptionType.STREAM_ONLINE:
                             logging.info("Process a stream online notification")
@@ -374,7 +376,7 @@ class EventSub(WebSocketApp):
     def __process_prediction_lock(self, event: dict):
         pred_title = event["title"]
         result = event["outcomes"]
-        self.__trigger_map.trigger(TriggerSignal.PREDICTION_BEGIN, param={"title": pred_title, "result": result})
+        self.__trigger_map.trigger(TriggerSignal.PREDICTION_LOCK, param={"title": pred_title, "result": result})
 
     def __process_prediction_end(self, event: dict):
         pred_title = event["title"]

--- a/twitchapi/eventsub.py
+++ b/twitchapi/eventsub.py
@@ -353,8 +353,8 @@ class EventSub(WebSocketApp):
             bits_amount_per_vote = event["bits_voting"]["amount_per_vote"]
             channel_point_enable = event["channel_points_voting"]["is_enabled"]
             channel_point_amount_per_vote = event["channel_points_voting"]["amount_per_vote"]
-            start_date = event["started_at"][-4]
-            end_date = event["ended_at"][-4]
+            start_date = event["started_at"][:-4]
+            end_date = event["ended_at"][:-4]
             self.__dbmanager.execute_script(DataBaseTemplate.POLL, id=id, title=poll_title, bits_enable=bits_enable,
                                             bits_amount_per_vote=bits_amount_per_vote, start_date=start_date,
                                             channel_point_enable=channel_point_enable, end_date=end_date,
@@ -388,14 +388,14 @@ class EventSub(WebSocketApp):
                 break
         if not winning:
             raise TwitchEventSubError(f"There's no winning prediction for {pred_title}")
-        self.__trigger_map.trigger(TriggerSignal.PREDICTION_BEGIN, param={"title": pred_title, "result": result,
+        self.__trigger_map.trigger(TriggerSignal.PREDICTION_END, param={"title": pred_title, "result": result,
                                                                           "winning_pred": winning})
 
         if self.__store_in_db:
             id = event["id"]
             winning_id = event["winning_outcome_id"]
-            start_date = event["started_at"][-4]
-            end_date = event["ended_at"][-4]
+            start_date = event["started_at"][:-4]
+            end_date = event["ended_at"][:-4]
             status = event["status"]
             self.__dbmanager.execute_script(DataBaseTemplate.PREDICTION, id=id, title=pred_title,
                                             winning_outcome=winning, winning_outcome_id=winning_id,

--- a/twitchapi/twitchcom.py
+++ b/twitchapi/twitchcom.py
@@ -1,6 +1,7 @@
 class TwitchEndpoint:
     TWITCH_ENDPOINT = "https://api.twitch.tv/helix/"
-    TWITCH_WEBSOCKET_URL = "wss://eventsub.wss.twitch.tv/ws"
+    # TWITCH_WEBSOCKET_URL = "wss://eventsub.wss.twitch.tv/ws"
+    TWITCH_WEBSOCKET_URL = "ws://localhost:8080/ws"
     TWITCH_AUTH_URL = "https://id.twitch.tv/oauth2/token"
 
     USER_ID = "users?login=<user_id>"

--- a/twitchapi/utils.py
+++ b/twitchapi/utils.py
@@ -86,4 +86,7 @@ class TriggerMap:
     def trigger(self, trigger_value: str, param: dict=None):
         if trigger_value not in self.__callbacks:
             raise KeyError(f"There's no callback react to {trigger_value}!!")
-        self.__callbacks[trigger_value](**param)
+        if param:
+            self.__callbacks[trigger_value](**param)
+        else:
+            self.__callbacks[trigger_value]()


### PR DESCRIPTION
### Fixed
- Add parameter to use database from ChatBot class
- Fix ban, poll end, prediction lock, prediction end trigger callback
- Fix start and end date for poll and prediction for database ingestion
- Fix call trigger callback with no parameter
- Fix insert sql request
- Call all table creation if no database exist